### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ python:
 before_install:
   - pip install pipenv
   - pipenv install --dev --skip-lock
-  - gem install sass
-  - npm install
+before_script:
+  - psql -c 'create database fundz_ci;' -U postgres
+  - pipenv run alembic upgrade head
 script:
   - python -m pytest
+services:
+  - postgresql
+env:
+  - FLASK_ENV=ci

--- a/config/base.ini
+++ b/config/base.ini
@@ -1,4 +1,4 @@
 [default]
 ENVIRONMENT = dev
-DEBUG = true
+DEBUG = false
 DATABASE_URI = postgres://postgres:postgres@localhost/fundz

--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,0 +1,2 @@
+[default]
+DATABASE_URI = postgres://postgres:postgres@localhost/fundz_ci

--- a/fundz/make_app.py
+++ b/fundz/make_app.py
@@ -21,11 +21,17 @@ def make_app(config):
 
 
 def make_config():
-    CONFIG_FILENAME = os.path.join(
+    BASE_CONFIG_FILENAME = os.path.join(
         os.path.dirname(__file__),
-        '..',
-        os.getenv('CONFIG_FILENAME', 'config.ini')
+        '../config/base.ini',
+    )
+    ENV_CONFIG_FILENAME = os.path.join(
+        os.path.dirname(__file__),
+        '../config/',
+        '{}.ini'.format(os.getenv('FLASK_ENV', 'dev').lower())
     )
     config = ConfigParser()
-    config.read(CONFIG_FILENAME)
+
+    # ENV_CONFIG will override values in BASE_CONFIG.
+    config.read([BASE_CONFIG_FILENAME, ENV_CONFIG_FILENAME])
     return map_config(config)

--- a/script/server
+++ b/script/server
@@ -6,8 +6,5 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-# Run the database
-docker-compose up -d db
-
 # Launch the app
 pipenv run python main.py ${@}

--- a/script/test
+++ b/script/test
@@ -6,8 +6,6 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-docker-compose up -d db
-
 if [ "$1" = "watch" ]; then
   ag -l -G [py]$ | entr pipenv run python -m pytest
 else

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,8 @@
 import pytest
 
-from fundz.make_app import make_app
+from fundz.make_app import make_app, make_config
 
 
 @pytest.fixture
 def app():
-    return make_app({
-        'SQLALCHEMY_DATABASE_URI': 'postgres://postgres:postgres@localhost/fundz',
-        'SQLALCHEMY_TRACK_MODIFICATIONS': False,
-        'ENVIRONMENT': 'test',
-        'DEBUG': False
-    })
+    return make_app(make_config())


### PR DESCRIPTION
Added a `postgresql` service to travis so that the tests can run.

I also modified the config setup so that we can have per-environment ini files. This makes it easier to specify a DB connection string for travis.

As a bonus, I removed the `docker-compose` invocations from the scripts. Now you can the database however you'd like.