### PR TITLE
make sure server script can reap child process

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+reap() {
+   kill -TERM $child
+   sleep 1
+   exit
+}
+
+trap reap TERM
+
 # If a command fails, exit the script
 set -e
 
@@ -7,4 +15,7 @@ set -e
 cd "$(dirname "${0}")/.."
 
 # Launch the app
-pipenv run python app.py ${@}
+pipenv run python app.py ${@} &
+child=$!
+
+wait "$child"


### PR DESCRIPTION
I'm going to make a comparable PR in every service.

In order to run the services under a process manager like Foreman, we need to make sure we trap and kill the child process correctly.