### PR TITLE
Trap INT too, and sleep less

### DIFF
--- a/script/server
+++ b/script/server
@@ -2,11 +2,11 @@
 
 reap() {
    kill -TERM $child
-   sleep 1
+   sleep 0.1
    exit
 }
 
-trap reap TERM
+trap reap TERM INT
 
 # If a command fails, exit the script
 set -e


### PR DESCRIPTION
This traps SIGINT, so that ^C with`script/server` will stop python.
Also, 0.1s seems like long enough to sleep.
I tested this on OS/X and Ubuntu.