### PR TITLE
determine type of pipenv install based on CI var

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -7,7 +7,11 @@ set -e
 cd "$(dirname "${0}")/.."
 
 # Install pipenv
-pip install pipenv --user
+if [ -n "${CI+set}" ]; then
+  pip install pipenv
+else
+  pip install -q pipenv --user
+fi
 pipenv --python 3.6
 
 # Install application dependencies

--- a/script/setup
+++ b/script/setup
@@ -7,7 +7,7 @@ set -e
 cd "$(dirname "${0}")/.."
 
 # Install pipenv
-if [ -n "${CI+set}" ]; then
+if [ -n "$CI" ]; then
   pip install pipenv
 else
   pip install -q pipenv --user


### PR DESCRIPTION
atat-stack needs to run each of the script/setup scripts, and the --user flag for pip install doesn't work. This makes it configurable with an env var.