### PR TITLE
drop CI suffix in db name for CI

### DIFF
--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,2 +1,2 @@
 [default]
-DATABASE_URI = postgres://postgres:postgres@localhost/fundz_ci
+DATABASE_URI = postgres://postgres:postgres@localhost/fundz

--- a/script/cibuild
+++ b/script/cibuild
@@ -6,5 +6,5 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-psql -c 'create database fundz_ci;' -U postgres
+psql -c 'create database fundz;' -U postgres
 pipenv run alembic upgrade head


### PR DESCRIPTION
Don't use the CI suffix for the database name.